### PR TITLE
Feature onInitialized callback with claims which is needed for ping events

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,13 @@ Checking if the user has an active session
 const { hasSession } = useAuthSessionInfo();
 console.log('Does the user have a session? ', hasSession)
 ```
+
+### Get the initialized data
+Checks when the loadInitialData function load on is done executing and will return with the claims or null,
+depending on if you were logged in or logged out on initialization.
+Default is undefined.
+
+```javascript
+const initializedData = useAuthInitialized();
+console.log('This is the initialized data: ', initializedData)
+```

--- a/README.md
+++ b/README.md
@@ -73,3 +73,11 @@ Checking if the user is logged in so that you can act on it.
 const isLoggedIn = useAuthIsLoggedIn();
 console.log('Is the user loggedin? ', isLoggedIn)
 ```
+
+### Check if a user has a session
+Checking if the user has an active session
+
+```javascript
+const { hasSession } = useAuthSessionInfo();
+console.log('Does the user have a session? ', hasSession)
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -5042,11 +5042,6 @@
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
       "dev": true
     },
-    "bowser": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
-      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
-    },
     "boxen": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
@@ -6613,6 +6608,7 @@
       "version": "1.0.0-alpha.37",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
       "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
+      "dev": true,
       "requires": {
         "mdn-data": "2.0.4",
         "source-map": "^0.6.1"
@@ -6621,7 +6617,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -8698,9 +8695,9 @@
       "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
     },
     "fastest-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
+      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.8.0",
@@ -10350,11 +10347,10 @@
       "dev": true
     },
     "inline-style-prefixer": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
-      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz",
+      "integrity": "sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==",
       "requires": {
-        "bowser": "^1.7.3",
         "css-in-js-utils": "^2.0.0"
       }
     },
@@ -11678,7 +11674,8 @@
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
@@ -12075,24 +12072,43 @@
       "optional": true
     },
     "nano-css": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.0.tgz",
-      "integrity": "sha512-uM/9NGK9/E9/sTpbIZ/bQ9xOLOIHZwrrb/CRlbDHBU/GFS7Gshl24v/WJhwsVViWkpOXUmiZ66XO7fSB4Wd92Q==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.1.tgz",
+      "integrity": "sha512-ENPIyNzANQRyYVvb62ajDd7PAyIgS2LIUnT9ewih4yrXSZX4hKoUwssy8WjUH++kEOA5wUTMgNnV7ko5n34kUA==",
       "requires": {
-        "css-tree": "^1.0.0-alpha.28",
-        "csstype": "^2.5.5",
-        "fastest-stable-stringify": "^1.0.1",
-        "inline-style-prefixer": "^4.0.0",
-        "rtl-css-js": "^1.9.0",
-        "sourcemap-codec": "^1.4.1",
-        "stacktrace-js": "^2.0.0",
-        "stylis": "3.5.0"
+        "css-tree": "^1.1.2",
+        "csstype": "^3.0.6",
+        "fastest-stable-stringify": "^2.0.2",
+        "inline-style-prefixer": "^6.0.0",
+        "rtl-css-js": "^1.14.0",
+        "sourcemap-codec": "^1.4.8",
+        "stacktrace-js": "^2.0.2",
+        "stylis": "^4.0.6"
       },
       "dependencies": {
+        "css-tree": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.2.tgz",
+          "integrity": "sha512-wCoWush5Aeo48GLhfHPbmvZs59Z+M7k5+B1xDnXbdWNcEF423DoFdqSWE0PM5aNk5nI5cp1q7ms36zGApY/sKQ==",
+          "requires": {
+            "mdn-data": "2.0.14",
+            "source-map": "^0.6.1"
+          }
+        },
         "csstype": {
-          "version": "2.6.14",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
-          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        },
+        "mdn-data": {
+          "version": "2.0.14",
+          "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+          "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -17638,9 +17654,9 @@
       "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
     },
     "react-use": {
-      "version": "15.3.4",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-15.3.4.tgz",
-      "integrity": "sha512-cHq1dELW6122oi1+xX7lwNyE/ugZs5L902BuO8eFJCfn2api1KeuPVG1M/GJouVARoUf54S2dYFMKo5nQXdTag==",
+      "version": "15.3.8",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-15.3.8.tgz",
+      "integrity": "sha512-GeGcrmGuUvZrY5wER3Lnph9DSYhZt5nEjped4eKDq8BRGr2CnLf9bDQWG9RFc7oCPphnscUUdOovzq0E5F2c6Q==",
       "requires": {
         "@types/js-cookie": "2.2.6",
         "@xobotyi/scrollbar-width": "1.9.5",
@@ -17659,9 +17675,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
-          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
         }
       }
     },
@@ -18595,9 +18611,9 @@
       }
     },
     "screenfull": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.2.tgz",
-      "integrity": "sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.1.0.tgz",
+      "integrity": "sha512-dYaNuOdzr+kc6J6CFcBrzkLCfyGcMg+gWkJ8us93IQ7y1cevhQAugFsaCdMHb6lw8KV3xPzSxzH7zM1dQap9mA=="
     },
     "sdu-react-scripts": {
       "version": "1.2.0",
@@ -19814,9 +19830,9 @@
       }
     },
     "stylis": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
-      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.6.tgz",
+      "integrity": "sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     }
   },
   "dependencies": {
-    "react-use": "^15.3.4",
+    "react-use": "^15.3.8",
     "zustand": "^3.1.4"
   }
 }

--- a/src/OidcJwtProvider.tsx
+++ b/src/OidcJwtProvider.tsx
@@ -4,10 +4,11 @@ import { UseStore } from 'zustand';
 import { createOidcJwtClientStore, OidcJwtClientOptions, UseOidcJwtClientStore } from './store';
 import { isSSR } from './utils/isSSR';
 
-interface OidcJwtProviderProps {
+export interface OidcJwtProviderProps {
   client: OidcJwtClientOptions;
   shouldAttemptLogin?: boolean;
   shouldMonitorAccessTokens?: boolean;
+  onInitialized?: (data: any | null) => void;
 }
 
 interface OidcJwtContextData {
@@ -29,6 +30,7 @@ const OidcJwtProvider: React.FC<OidcJwtProviderProps> = (props) => {
     client: options,
     shouldAttemptLogin = false,
     shouldMonitorAccessTokens = true,
+    onInitialized,
     children,
   } = props;
 
@@ -43,7 +45,7 @@ const OidcJwtProvider: React.FC<OidcJwtProviderProps> = (props) => {
 
   const {
     authorize,
-    receiveSessionToken,
+    loadInitialData,
     monitorAccessToken,
     stopMonitoringAccessToken,
   } = useStore(state => state.methods);
@@ -51,8 +53,10 @@ const OidcJwtProvider: React.FC<OidcJwtProviderProps> = (props) => {
   const isLoggedIn = useStore(state => state.isLoggedIn);
   const isCSRFTokenPresent = !!useStore(state => state.csrfToken);
   useEffect(() => {
-    receiveSessionToken();
-  }, [receiveSessionToken]);
+    loadInitialData().then(data => {
+      if (onInitialized) onInitialized(data);
+    });
+  }, [loadInitialData, onInitialized]);
 
   useEffect(() => {
     if (!isLoggedIn) return;

--- a/src/OidcJwtProvider.tsx
+++ b/src/OidcJwtProvider.tsx
@@ -8,7 +8,6 @@ export interface OidcJwtProviderProps {
   client: OidcJwtClientOptions;
   shouldAttemptLogin?: boolean;
   shouldMonitorAccessTokens?: boolean;
-  onInitialized?: (data: any | null) => void;
 }
 
 interface OidcJwtContextData {
@@ -30,7 +29,6 @@ const OidcJwtProvider: React.FC<OidcJwtProviderProps> = (props) => {
     client: options,
     shouldAttemptLogin = false,
     shouldMonitorAccessTokens = true,
-    onInitialized,
     children,
   } = props;
 
@@ -52,11 +50,10 @@ const OidcJwtProvider: React.FC<OidcJwtProviderProps> = (props) => {
 
   const isLoggedIn = useStore(state => state.isLoggedIn);
   const isCSRFTokenPresent = !!useStore(state => state.csrfToken);
+
   useEffect(() => {
-    loadInitialData().then(data => {
-      if (onInitialized) onInitialized(data);
-    });
-  }, [loadInitialData, onInitialized]);
+    loadInitialData();
+  }, [loadInitialData]);
 
   useEffect(() => {
     if (!isLoggedIn) return;

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -61,6 +61,11 @@ function useAuthAccessToken(): { (): Promise<string | null> } {
   return () => getAccessToken().then(result => result?.token ?? null);
 }
 
+function useAuthInitialized(): any {
+  const { useStore } = useOidcJwtContext();
+  return useStore(state => state.initializedData);
+}
+
 export {
   useAuthControls,
   useAuthUserInfo,
@@ -68,4 +73,5 @@ export {
   useAuthIsLoggedIn,
   useAuthAccessToken,
   useAuthSessionInfo,
+  useAuthInitialized,
 };

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -49,6 +49,12 @@ function useAuthIsLoggedIn(): boolean {
   return useStore(state => state.isLoggedIn);
 }
 
+function useAuthSessionInfo(): { hasSession: boolean } {
+  const { useStore } = useOidcJwtContext();
+  const hasSession = useStore(state => !!state.csrfToken);
+  return { hasSession };
+}
+
 function useAuthAccessToken(): { (): Promise<string | null> } {
   const { useStore } = useOidcJwtContext();
   const getAccessToken = useStore(state => state.methods.getAccessToken);
@@ -61,4 +67,5 @@ export {
   useAuthAccessClaims,
   useAuthIsLoggedIn,
   useAuthAccessToken,
+  useAuthSessionInfo,
 };

--- a/src/stories/Login.stories.tsx
+++ b/src/stories/Login.stories.tsx
@@ -5,6 +5,7 @@ import {
   useAuthAccessClaims,
   useAuthAccessToken,
   useAuthControls,
+  useAuthInitialized,
   useAuthIsLoggedIn,
   useAuthSessionInfo,
   useAuthUserInfo,
@@ -92,6 +93,7 @@ const Content = (props: ContentProps) => {
   const { authorize, logout } = useAuthControls();
   const fetchAccessToken = useAuthAccessToken();
   const isLoggedIn = useAuthIsLoggedIn();
+  const initializedData = useAuthInitialized();
 
   const onClickFetchToken = React.useCallback(() => {
     fetchAccessToken().then((token) => {
@@ -151,6 +153,8 @@ const Content = (props: ContentProps) => {
         )}
       </div>
       <hr />
+      <h1>Initialized data</h1>
+      <LargeTextArea value={JSON.stringify(initializedData, undefined, 4)}></LargeTextArea>
       <h1>Session info</h1>
       <LargeTextArea value={JSON.stringify(sessionInfo, undefined, 4)}></LargeTextArea>
       <h1>User info</h1>

--- a/src/stories/Login.stories.tsx
+++ b/src/stories/Login.stories.tsx
@@ -6,6 +6,7 @@ import {
   useAuthAccessToken,
   useAuthControls,
   useAuthIsLoggedIn,
+  useAuthSessionInfo,
   useAuthUserInfo,
 } from '../hooks';
 import { OidcJwtProvider } from '../OidcJwtProvider';
@@ -83,6 +84,7 @@ interface Claims {
 
 const Content = (props: ContentProps) => {
   const { testApiUrl } = props;
+  const sessionInfo = useAuthSessionInfo();
   const { value: userInfo } = useAuthUserInfo<UserInfo>();
   const [token, setToken] = useState<null | string>(null);
   const [apiResult, setApiResult] = useState<null | string>(null);
@@ -149,6 +151,8 @@ const Content = (props: ContentProps) => {
         )}
       </div>
       <hr />
+      <h1>Session info</h1>
+      <LargeTextArea value={JSON.stringify(sessionInfo, undefined, 4)}></LargeTextArea>
       <h1>User info</h1>
       <LargeTextArea value={JSON.stringify(userInfo, undefined, 4)}></LargeTextArea>
       <h1>Access token claims</h1>


### PR DESCRIPTION
To send a tracking event like so:

_pingKeyAvailable event_
This event should be pushed on every page view, even if the user is not logged in with Ping. If the user has a Ping session with this website, the pingKey value should be filled. Otherwise it should be null. It should only be called on the actual page load, and not on virtual navigation (e.g. hash-based routing or pushState).

The event should be pushed even if the user is logged in with Ping under an account that does not provide access to the current website. The pingKeyValidForCurrentProduct value in the event reflects this: it should be true if the user’s Ping account gives them access to this website, and false otherwise.

We need to know when your login is initialized or when you are logged out and the provider is initalized
