### PR TITLE
fix: use localStorage value of csrfToken directly because store rerendertick is too late

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -139,7 +139,7 @@ export interface OidcJwtClientOptions {
   defaultAuthConfig?: Params;
 }
 
-const CSRF_TOKEN_STORAGE_KEY = 'oidc_jwt_provider_token';
+export const CSRF_TOKEN_STORAGE_KEY = 'oidc_jwt_provider_token';
 const LOGGED_IN_TOKEN_STORAGE_KEY = 'oidc_jwt_provider_logged_in';
 const USER_INFO_TOKEN_STORAGE_KEY = 'oidc_jwt_provider_user_info';
 


### PR DESCRIPTION
When you return from ping after authorize has run on load, csrfToken gets set in store.
At the same time it starts running getInitialData. 
At the same render tick the useEffect at the bottom is called and will call the authorize again because it needs another render tick before store value update triggers (hooks rule). 
This would make authorize() be called twice and only the third time the csrftoken would be set. This is not good. Therefor the simplest way is just to read out the csrftoken from LS directly.