### PR TITLE
fix: prevent rerenders from useAuthAccessToken

### DIFF
--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useAsync, usePrevious } from 'react-use';
 import { AsyncState } from 'react-use/lib/useAsync';
 
@@ -76,7 +76,9 @@ function useAuthSessionExpired(): boolean {
 function useAuthAccessToken(): { (): Promise<string | null> } {
   const { useStore } = useOidcJwtContext();
   const getAccessToken = useStore(state => state.methods.getAccessToken);
-  return () => getAccessToken().then(result => result?.token ?? null);
+  return useCallback(() => {
+    return getAccessToken().then(result => result?.token ?? null);
+  }, [getAccessToken]);
 }
 
 export {


### PR DESCRIPTION
Say I have this code:

```
  const getAccessToken = useAuthAccessToken();
  const isLoggedIn = useAuthIsLoggedIn();
  const [apiResponse, setApiResponse] = useState<any>(null);

  const doApiCall = useCallback(async () => {
    const token = await getAccessToken();
    if (!token) {
      return;
    }
    const response = await fetch(
      "https://my-api/somepath",
      {
        headers: {
          authorization: `Bearer ${token}`,
        },
      }
    );
    const json = await response.json();
    setApiResponse(json);
  }, [getAccessToken, setApiResponse]);

  useEffect(() => {
    if (isLoggedIn) {
      doApiCall();
    }
  }, [isLoggedIn, doApiCall]);
```

Then because getAccessToken always returned a fresh function, on every render doApiCall became a new function as well, so the useEffect was called on every rerender. The result was infinite calls to the API.

This fix will make the code work as expected.